### PR TITLE
Return a response error with error message

### DIFF
--- a/lib/wazuh/api/errors/wazuh_error.rb
+++ b/lib/wazuh/api/errors/wazuh_error.rb
@@ -2,11 +2,11 @@ module Wazuh
   module Api
     module Errors
       class WazuhError < ::Faraday::Error
-        attr_reader :response
+        attr_reader :response, :message
 
         def initialize(message, response = nil)
+          @message = message
           @response = response
-          super message
         end
       end
     end

--- a/lib/wazuh/faraday/response/raise_error.rb
+++ b/lib/wazuh/faraday/response/raise_error.rb
@@ -4,6 +4,9 @@ module Wazuh
     module Response
       class RaiseError < ::Faraday::Response::Middleware
         def on_complete(env)
+          return if env.status == 200 || env.body['error'] == 0
+          error_message = env.body['message']
+          raise Wazuh::Api::Errors::WazuhError.new(error_message, env.response)
         end
       end
     end


### PR DESCRIPTION
Makes the response object accessible if Wazuh api returns an error.

example: 

```ruby
begin
  client.all_agents({q: "'invalid-param'"})
rescue => e
  puts e.message
  # => Param not valid. Review queries documentation: https://documentation.wazuh.com/current/user-manual/api/queries.html.  Field: q
  puts e.response
  # => #<Faraday::Response:0x00007fe9662c4640>
end
```