### PR TITLE
Get all items with `offset_request`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Gemfile.lock
 *.crt
 *.key
 *.ca
+*.bak
 .env
 .bundle
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Get all items with `offset_request`
+  - So far only 500 items(Wazuh API default) have been retrieved that contain a `totalItems` field such as `#all_agents` .
+  - For such an endpoint, implemented `offset_request` to fetch all items.
+  - This change does not change the type of the return value. However, it may take some time because it sends repeated requests to get all the items.
+
 ## [0.2.4] - 2020-03-31
 
 - `agents_by_group` also returns the `item` field.

--- a/lib/wazuh/api/endpoints/agents.rb
+++ b/lib/wazuh/api/endpoints/agents.rb
@@ -23,8 +23,7 @@ module Wazuh
         # @return [Array] Returns Array containing agents
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-agents
         def all_agents(options = {})
-          data = get '/agents', options
-          data.items
+          offset_request('get', '/agents', options)
         end
 
         # Returns various information from an agent.
@@ -290,8 +289,7 @@ module Wazuh
         # @option options [String] q
         # @see https://documentation.wazuh.com/3.11/user-manual/api/reference.html#get-agents-in-a-group
         def agents_by_group(group_id, options = {})
-          data = get "/agents/groups/#{group_id}", options
-          data.items
+          offset_request('get', "/agents/groups/#{group_id}", options)
         end
 
         # Get agents without group

--- a/lib/wazuh/api/endpoints/ciscat.rb
+++ b/lib/wazuh/api/endpoints/ciscat.rb
@@ -35,8 +35,7 @@ module Wazuh
         #   Filters by final score.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-cis-cat-results-from-an-agent
         def ciscat_result(agent_id, options = {})
-          data = get "/ciscat/#{agent_id}/results", options
-          data.items
+          offset_request("get", "/ciscat/#{agent_id}/results", options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/cluster.rb
+++ b/lib/wazuh/api/endpoints/cluster.rb
@@ -116,8 +116,7 @@ module Wazuh
         # @option options [category] :category
         #   Filters by category of log
         def cluster_logs_by_node(node_id, options)
-          data = get "/cluster/#{node_id}/logs", options
-          data.items
+          offset_request("get", "/cluster/#{node_id}/logs", options)
         end
 
         # Get summary of ossec.log from a specific node in cluster
@@ -142,8 +141,7 @@ module Wazuh
         # Get nodes info
         #
         def nodes(options = {})
-          data = get '/cluster/nodes', options
-          data.items
+          offset_request('get', '/cluster/nodes', options)
         end
 
         # Restart a specific node in cluster

--- a/lib/wazuh/api/endpoints/decoders.rb
+++ b/lib/wazuh/api/endpoints/decoders.rb
@@ -23,8 +23,7 @@ module Wazuh
         #   Allowed values: enabled, disabled, all
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-decoders
         def all_decoders(options = {})
-          data = get '/decoders', options
-          data.items
+          offset_request("get", "/decoders", options)
         end
 
         # Get all decoders files
@@ -50,8 +49,7 @@ module Wazuh
         #   Name of the decoder file to download.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-decoders-files
         def all_decoders_files(options = {})
-          data = get '/decoders/files', options
-          data.items
+          offset_request('get', '/decoders/files', options)
         end
 
         # Get all parent decoders
@@ -67,8 +65,7 @@ module Wazuh
         #   Looks for elements with the specified string.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-parent-decoders
         def all_parent_decoders(options = {})
-          data = get '/decoders/parents', options
-          data.items
+          offset_request('get', '/decoders/parents', options)
         end
 
         # Get decoders by name
@@ -86,8 +83,7 @@ module Wazuh
         #   Looks for elements with the specified string.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-decoders-by-name
         def decoders_by_name(decoder_name, options = {})
-          data = get "/decoders/#{decoder_name}", options
-          data.items
+          offset_request("get", "/decoders/#{decoder_name}", options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/experimental.rb
+++ b/lib/wazuh/api/endpoints/experimental.rb
@@ -42,8 +42,7 @@ module Wazuh
         #   Filters by board_serial.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-hardware-info-of-all-agents
         def experimental_hardware(options = {})
-          data = get '/experimental/syscollector/hardware', options
-          data.items
+          offset_request('get', '/experimental/syscollector/hardware', options)
         end
 
         # Get network address info of all agents
@@ -72,8 +71,7 @@ module Wazuh
         #   Filters by netmask.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-address-info-of-all-agents
         def experimental_netaddr(options = {})
-          data = get '/experimental/syscollector/netaddr', options
-          data.items
+          offset_request('get', '/experimental/syscollector/netaddr', options)
         end
 
         # Get network interface info of all agents
@@ -109,8 +107,7 @@ module Wazuh
         # @option options [rx_dropped] :rx_dropped
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-interface-info-of-all-agents
         def experimental_netiface(options = {})
-          data = get '/experimental/syscollector/netiface', options
-          data.items
+          offset_request('get', '/experimental/syscollector/netiface', options)
         end
 
         # Get network protocol info of all agents
@@ -137,8 +134,7 @@ module Wazuh
         #   Filters by dhcp.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-protocol-info-of-all-agents
         def experimental_netproto(options = {})
-          data = get '/experimental/syscollector/netproto', options
-          data.items
+          offset_request('get', '/experimental/syscollector/netproto', options)
         end
 
         # Get os info of all agents
@@ -168,8 +164,7 @@ module Wazuh
         #   Filters by release.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-os-info-of-all-agents
         def experimental_os(options = {})
-          data = get '/experimentalsyscollector/os', options
-          data.items
+          offset_request('get', '/experimentalsyscollector/os', options)
         end
 
         # Get packages info of all agents
@@ -198,8 +193,7 @@ module Wazuh
         #   Filters by format.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-packages-info-of-all-agents
         def experimental_packages(options = {})
-          data = get '/experimental/syscollector/packages', options
-          data.items
+          offset_request('get', '/experimental/syscollector/packages', options)
         end
 
         # Get ports info of all agents
@@ -232,8 +226,7 @@ module Wazuh
         #   Filters by state.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-ports-info-of-all-agents
         def experimental_ports(options = {})
-          data = get '/experimental/syscollector/ports', options
-          data.items
+          offset_request('get', '/experimental/syscollector/ports', options)
         end
 
         # Get processes info of all agents
@@ -280,8 +273,7 @@ module Wazuh
         #   Filters by process suser.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-processes-info-of-all-agents
         def experimental_processes(options = {})
-          data = get '/experimental/syscollector/processes', options
-          data.items
+          offset_request('get', '/experimental/syscollector/processes', options)
         end
 
         # Get CIS-CAT results
@@ -309,8 +301,7 @@ module Wazuh
         # @option options [score] :score
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-cis-cat-results
         def experimental_ciscat_results(options = {})
-          data = get '/experimental/ciscat/results', options
-          data.items
+          offset_request('get', '/experimental/ciscat/results', options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/lists.rb
+++ b/lib/wazuh/api/endpoints/lists.rb
@@ -18,8 +18,7 @@ module Wazuh
         #   Filters by path.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-lists
         def cdb_lists(options = {})
-          data = get '/lists', options
-          data.items
+          offset_request('get', '/lists', options)
         end
 
         # Get paths from all lists
@@ -35,8 +34,7 @@ module Wazuh
         #   Looks for elements with the specified string.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-paths-from-all-lists
         def cdb_files_path(options = {})
-          data = get '/lists/files', options
-          data.items
+          offset_request('get', '/lists/files', options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/manager.rb
+++ b/lib/wazuh/api/endpoints/manager.rb
@@ -90,8 +90,7 @@ module Wazuh
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-ossec-log
         def manager_log
-          data = get '/manager/logs'
-          data.items
+          offset_request('get', '/manager/logs')
         end
 
         # Get summary of ossec.log

--- a/lib/wazuh/api/endpoints/rootcheck.rb
+++ b/lib/wazuh/api/endpoints/rootcheck.rb
@@ -39,8 +39,7 @@ module Wazuh
         # @option options [search] :search
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rootcheck-cis-requirements
         def rootcheck_cis_requirements(agent_id, options = {})
-          data = get "/rootcheck/#{agent_id}/cis", options
-          data.items
+          offset_request('get', "/rootcheck/#{agent_id}/cis", options)
         end
 
         # Get rootcheck database
@@ -56,8 +55,7 @@ module Wazuh
         # @option options [status] :status
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rootcheck-database
         def rootcheck_database(agent_id, options = {})
-          data = get "/rootcheck/#{agent_id}", options
-          data.items
+          offset_request('get', "/rootcheck/#{agent_id}", options)
         end
 
         # Get rootcheck pci requirements
@@ -70,8 +68,7 @@ module Wazuh
         # @option options [search] :search
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rootcheck-pci-requirements
         def rootcheck_pic_requirements(agent_id, options = {})
-          data = get "/rootcheck/#{agent_id}/pci", options
-          data.items
+          offset_request('get', "/rootcheck/#{agent_id}/pci", options)
         end
 
         # Run rootcheck scan in all agents

--- a/lib/wazuh/api/endpoints/rules.rb
+++ b/lib/wazuh/api/endpoints/rules.rb
@@ -7,64 +7,56 @@ module Wazuh
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-all-rules
         def all_rules(options = {})
-          data = get '/rules', options
-          data.items
+          offset_request('get', '/rules', options)
         end
 
         # Returns the files of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-files-of-rules
         def rule_files(options = {})
-          data = get '/rules/files', options
-          data.items
+          offset_request('get', '/rules/files', options)
         end
 
         # Returns the GDPR requirements of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-gdpr-requirements
         def gdpr_rules(options = {})
-          data = get '/rules/gdpr', options
-          data.items
+          offset_request('get', '/rules/gdpr', options)
         end
 
         # Returns the GPG13 requirements of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-gpg13-requirements
         def gpg13_rules(options = {})
-          data = get '/rules/gpg13', options
-          data.items
+          offset_request('get', '/rules/gpg13', options)
         end
 
         # Returns the groups of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-groups
         def rules_groups(options = {})
-          data = get '/rules/groups', options
-          data.items
+          offset_request('get', '/rules/groups', options)
         end
 
         # Returns the HIPAA requirements of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-hipaa-requirements
         def hipaa_rules(options = {})
-          data = get '/rules/hipaa', options
-          data.items
+          offset_request('get', '/rules/hipaa', options)
         end
 
         # Returns the NIST-800-53 requirements of all rules.
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-nist-800-53-requirements
         def nist_800_53_rules(options = {})
-          data = get '/rules/nist-800-53', options
-          data.items
+         offset_request('get', '/rules/nist-800-53', options)
         end
 
         # Returns the PCI requirements of all rules
         #
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rule-pci-requirements
         def pic_rules(options = {})
-          data = get '/rules/pci', options
-          data.items
+          offset_request('get', '/rules/pci', options)
         end
 
         # Returns the rules with the specified id.
@@ -80,8 +72,7 @@ module Wazuh
         #   Looks for elements with the specified string.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-rules-by-id
         def rule_by_id(rule_id, options = {})
-          data = get "/rules/#{rule_id}", options
-          data.items
+          offset_request('get', "/rules/#{rule_id}", options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/security_configuration_assessment.rb
+++ b/lib/wazuh/api/endpoints/security_configuration_assessment.rb
@@ -39,8 +39,7 @@ module Wazuh
         #   Looks for elements with the specified string.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-security-configuration-assessment-sca-checks-database
         def checks_sca_database(agent_id, policy_id, options = {})
-          data = get "/sca/#{agent_id}/checks/#{policy_id}", options
-          data.items
+          offset_request('get', "/sca/#{agent_id}/checks/#{policy_id}", options)
         end
 
         # Get security configuration assessment (SCA) database
@@ -66,8 +65,7 @@ module Wazuh
         #   Query to filter results by. This is specially useful to filter by total checks passed, failed or total score (fields pass, fail, score).
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-security-configuration-assessment-sca-database
         def sca_database(agent_id, options = {})
-          data = get "/sca/#{agent_id}", options
-          data.items
+          offset_request('get', "/sca/#{agent_id}", options)
         end
       end
     end

--- a/lib/wazuh/api/endpoints/syscheck.rb
+++ b/lib/wazuh/api/endpoints/syscheck.rb
@@ -33,8 +33,7 @@ module Wazuh
         #   Returns the files with the specified hash (md5, sha1 or sha256).
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-syscheck-files
         def syscheck_files(agent_id, options = {})
-          data = get "/syscheck/#{agent_id}", options
-          data.items
+          offset_request('get', "/syscheck/#{agent_id}", options)
         end
 
         # Clears the syscheck database for the specified agent.

--- a/lib/wazuh/api/endpoints/syscollector.rb
+++ b/lib/wazuh/api/endpoints/syscollector.rb
@@ -38,8 +38,7 @@ module Wazuh
         #   Filters by netmask.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-address-info-of-an-agent
         def netaddr(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/netaddr", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/netaddr", options)
         end
 
         # Returns the agent’s network interface info
@@ -75,8 +74,7 @@ module Wazuh
         # @option options [rx_dropped] :rx_dropped
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-interface-info-of-an-agent
         def netiface(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/netiface", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/netiface", options)
         end
 
         # Returns the agent’s network protocol info.
@@ -102,8 +100,7 @@ module Wazuh
         #   Filters by dhcp.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-network-protocol-info-of-an-agent
         def netproto(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/netproto", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/netproto", options)
         end
 
         # Returns the agent’s OS info.
@@ -141,8 +138,7 @@ module Wazuh
         #   Filters by format.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-packages-info
         def packages(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/packages", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/packages", options)
         end
 
         # Get ports info of an agent
@@ -175,8 +171,7 @@ module Wazuh
         #   Filters by state.
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-ports-info-of-an-agent
         def ports(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/ports", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/ports", options)
         end
 
         # Get processes info
@@ -224,8 +219,7 @@ module Wazuh
         # 
         # @see https://documentation.wazuh.com/3.10/user-manual/api/reference.html#get-processes-info
         def processes(agent_id, options = {})
-          data = get "/syscollector/#{agent_id}/processes", options
-          data.items
+          offset_request('get', "/syscollector/#{agent_id}/processes", options)
         end
       end
     end

--- a/lib/wazuh/sawyer/request.rb
+++ b/lib/wazuh/sawyer/request.rb
@@ -18,6 +18,18 @@ module Wazuh
         request(:delete, path, options)
       end
 
+      def offset_request(method, path, options = {})
+        items = []
+        data = send(method, path, options)
+        0.step(data.totalItems, 500) { |offset|
+          options[:offset] = offset
+          d = send(method, path, options)
+          items.concat(d.items)
+        }
+
+        items
+      end
+
       private
 
       def request(method, path, options)

--- a/spec/vcr/api/endpoints/all_agents.yml
+++ b/spec/vcr/api/endpoints/all_agents.yml
@@ -2,6 +2,128 @@
 http_interactions:
 - request:
     method: get
+    uri: https://wazuh.local:55000/agents?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Wazuh Ruby Client/0.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "error": 0,
+          "data": {
+             "items": [
+                {
+                   "registerIP": "any",
+                   "name": "myNewAgent",
+                   "status": "Never connected",
+                   "dateAdd": "2019-08-30 09:31:02",
+                   "node_name": "unknown",
+                   "ip": "any",
+                   "id": "010"
+                },
+                {
+                   "os": {
+                      "arch": "x86_64",
+                      "major": "7",
+                      "minor": "6",
+                      "name": "CentOS Linux",
+                      "platform": "centos",
+                      "uname": "Linux |7084a5343d0a |5.2.9-200.fc30.x86_64 |#1 SMP Fri Aug 16 21:37:45 UTC 2019 |x86_64",
+                      "version": "7.6"
+                   },
+                   "registerIP": "172.22.0.6",
+                   "name": "7084a5343d0a",
+                   "mergedSum": "6c2a4b148047e590188f8befe47c2bff",
+                   "status": "Active",
+                   "group": [
+                      "default"
+                   ],
+                   "dateAdd": "2019-08-30 09:18:12",
+                   "configSum": "ab73af41699f13fdd81903b5f23d8d00",
+                   "lastKeepAlive": "2019-08-30 09:31:04",
+                   "node_name": "worker-1",
+                   "ip": "172.22.0.6",
+                   "id": "002",
+                   "version": "Wazuh v3.10.2",
+                   "manager": "7995615e03c0"
+                },
+                {
+                   "os": {
+                      "arch": "x86_64",
+                      "major": "7",
+                      "minor": "6",
+                      "name": "CentOS Linux",
+                      "platform": "centos",
+                      "uname": "Linux |1b0e9cb1ec2a |5.2.9-200.fc30.x86_64 |#1 SMP Fri Aug 16 21:37:45 UTC 2019 |x86_64",
+                      "version": "7.6"
+                   },
+                   "registerIP": "172.22.0.3",
+                   "name": "1b0e9cb1ec2a",
+                   "mergedSum": "6c2a4b148047e590188f8befe47c2bff",
+                   "status": "Active",
+                   "group": [
+                      "default"
+                   ],
+                   "dateAdd": "1970-01-01 00:00:00",
+                   "configSum": "ab73af41699f13fdd81903b5f23d8d00",
+                   "lastKeepAlive": "2019-08-30 09:31:03",
+                   "node_name": "master",
+                   "ip": "172.22.0.3",
+                   "id": "001",
+                   "version": "Wazuh v3.10.2",
+                   "manager": "1cb46c820ff5"
+                },
+                {
+                   "os": {
+                      "arch": "x86_64",
+                      "major": "7",
+                      "minor": "6",
+                      "name": "CentOS Linux",
+                      "platform": "centos",
+                      "uname": "Linux |1cb46c820ff5 |5.2.9-200.fc30.x86_64 |#1 SMP Fri Aug 16 21:37:45 UTC 2019 |x86_64",
+                      "version": "7.6"
+                   },
+                   "registerIP": "127.0.0.1",
+                   "name": "1cb46c820ff5",
+                   "status": "Active",
+                   "dateAdd": "2019-08-30 08:02:33",
+                   "lastKeepAlive": "9999-12-31 23:59:59",
+                   "node_name": "master",
+                   "ip": "127.0.0.1",
+                   "id": "000",
+                   "version": "Wazuh v3.10.2",
+                   "manager": "1cb46c820ff5"
+                },
+                {
+                   "registerIP": "10.0.10.10",
+                   "name": "NewHost_2",
+                   "status": "Never connected",
+                   "dateAdd": "2019-08-30 09:31:03",
+                   "node_name": "unknown",
+                   "ip": "10.0.10.10",
+                   "id": "123"
+                }
+             ],
+             "totalItems": 10
+          }
+        }
+    http_version:
+  recorded_at: Wed, 22 Jan 2020 09:39:56 GMT
+- request:
+    method: get
     uri: https://wazuh.local:55000/agents
     body:
       encoding: US-ASCII


### PR DESCRIPTION
So far only 500 items(Wazuh API default) have been retrieved that contain a `totalItems` field such as `#all_agents` .
 
For such an endpoint, implemented `offset_request` to fetch all items.

This change does not change the type of the return value. However, it may take some time because it sends repeated requests to get all the items.