### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.5]
+
 - Get all items with `offset_request`
   - So far only 500 items(Wazuh API default) have been retrieved that contain a `totalItems` field such as `#all_agents` .
   - For such an endpoint, implemented `offset_request` to fetch all items.

--- a/lib/wazuh-ruby-client/version.rb
+++ b/lib/wazuh-ruby-client/version.rb
@@ -1,3 +1,3 @@
 module WazuhRubyClient
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/lib/wazuh/version.rb
+++ b/lib/wazuh/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Wazuh
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
- Get all items with `offset_request` #16 
  - So far only 500 items(Wazuh API default) have been retrieved that contain a `totalItems` field such as `#all_agents` .
  - For such an endpoint, implemented `offset_request` to fetch all items.
  - This change does not change the type of the return value. However, it may take some time because it sends repeated requests to get all the items.