### PR TITLE
bump up to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.6]
+
 - Support agent upgrade endpoint
   - `/agents/:agent_id/upgrade_custom`
   - `/agents/:agent_id/upgrade`

--- a/lib/wazuh-ruby-client/version.rb
+++ b/lib/wazuh-ruby-client/version.rb
@@ -1,3 +1,3 @@
 module WazuhRubyClient
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/lib/wazuh/version.rb
+++ b/lib/wazuh/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Wazuh
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
- Support agent upgrade endpoint
  - `/agents/:agent_id/upgrade_custom`
  - `/agents/:agent_id/upgrade`