### PR TITLE
Adds availability to ignore env proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following global settings are supported via `Wazuh.configure` .
 | verify_ssl | Skip the SSL/TLS verify |
 | logger | loggeer object |
 | endpoint | Wazuh API endpoint URL |
+| ignore_env_proxy | Ignores ENV proxy settings |
 
 
 ### Agents

--- a/lib/wazuh/config.rb
+++ b/lib/wazuh/config.rb
@@ -12,6 +12,7 @@ module Wazuh
       verify_ssl
       logger
       endpoint
+      ignore_env_proxy
     ].freeze
 
     attr_accessor(*Config::ATTRIBUTES)
@@ -25,6 +26,7 @@ module Wazuh
       self.basic_password = nil
       self.verify_ssl = true
       self.logger = nil
+      self.ignore_env_proxy = false
     end
   end
 

--- a/lib/wazuh/sawyer/connection.rb
+++ b/lib/wazuh/sawyer/connection.rb
@@ -27,6 +27,7 @@ module Wazuh
         }
 
         opts[:faraday] = ::Faraday.new(options)
+        opts[:faraday].proxy = nil if ignore_env_proxy
 
         ::Sawyer::Agent.new(endpoint, opts)
       end


### PR DESCRIPTION
This option can be used when a server is configured with proxy and wazuh listens to localhost.
Otherwise, without such a feature faraday uses the default env proxy, and wazuh-ruby-client returns an error. 