### PR TITLE
remove faraday_middleware (deprecated) 

### DIFF
--- a/lib/wazuh-ruby-client.rb
+++ b/lib/wazuh-ruby-client.rb
@@ -7,7 +7,6 @@ require 'base64'
 require 'faraday'
 require 'sawyer'
 require 'jwt'
-require 'faraday_middleware'
 
 require_relative 'wazuh/config'
 require_relative 'wazuh/sawyer/token'

--- a/wazuh-ruby-client.gemspec
+++ b/wazuh-ruby-client.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
 
   spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'sawyer'
   spec.add_dependency 'jwt'
 end


### PR DESCRIPTION
Hello mrtc0 さん 🌳🐙

faraday_middleware is deprecated. ref https://github.com/lostisland/faraday_middleware

> As highlighted in Faraday's [UPGRADING](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) guide, faraday_middleware is DEPRECATED, and will not be updated to support Faraday 2.0. If you rely on faraday_middleware in your project and would like to support Faraday 2.0:
> https://github.com/lostisland/faraday_middleware

When trying to upgrade to the 2.x version of Faraday in a Rails project, Faraday was locked to the 1.x version due to the dependency of wazuh-ruby-client -> faraday_middleware

## 日本語で OK

 * faraday_middleware が deprecated なので、Gem の依存から削除する PR です
 * とある Rails プロジェクトで faraday を 2 系のバージョンに上げようとすると、wazuh-ruby-client -> faraday_middleware のの依存によって Faraday が 1系にロックされてしまいました

### 手動での確認

データが取れることも確認済みです

```
rails(dev)> Wazuh::Client.new.agent("000")
=> 
{:affected_items=>
  [{:os=>
     {:arch=>"x86_64",
      :major=>"2023",
      :name=>"Amazon Linux",
      :platform=>"amzn",
      :uname=>
       "Linux |wazuh-manager |5.15.0-25-generic |#25-Ubuntu SMP Wed Mar 30 15:54:22 UTC 2022 |x86_64",
      :version=>"2023"},
    :lastKeepAlive=>"9999-12-31T23:59:59+00:00",
    :version=>"Wazuh v4.9.1",
    :registerIP=>"127.0.0.1",
    :name=>"wazuh-manager",
    :group_config_status=>"synced",
    :node_name=>"***",
    :manager=>"***",
    :ip=>"127.0.0.1",
    :status_code=>0,
    :dateAdd=>"2020-06-23T14:35:10+00:00",
    :id=>"000",
    :status=>"active"}],
 :total_affected_items=>1,
 :total_failed_items=>0,
 :failed_items=>[]}
```

```
rails(dev)> Wazuh::Client.new.packages("000").first
=> 
{:scan=>{:id=>0, :time=>"2024-06-20T01:13:55+00:00"},
 :section=>" ",
 :format=>"pypi",
 :version=>"1.15.1",
 :architecture=>" ",
 :location=>"/usr/lib64/python3.9/site-packages/gpg-1.15.1-py3.9.egg-info",
 :size=>0,
 :name=>"gpg",
 :vendor=>" ",
 :source=>" ",
 :description=>" ",
 :install_time=>" ",
 :priority=>" ",
 :agent_id=>"000"}
```
